### PR TITLE
WIP: DO NOT MERGE Basic button idea

### DIFF
--- a/lib/grovepi/button.ex
+++ b/lib/grovepi/button.ex
@@ -1,0 +1,102 @@
+require IEx
+defmodule GrovePi.Button do
+  use Supervisor
+  @moduledoc """
+  Listen for the state of a button and send notification of change
+
+  Example usage:
+
+  iex> {:ok, grove_pid}=GrovePi.start_link
+  iex> {:ok, pid} = GrovePi.Button.start_link(grove_pid, pin)
+
+  repleased
+  iex> GrovePi.Button.read(pid)
+  0
+
+  pressed
+  iex> GrovePi.Button.read(pid)
+  1
+
+  iex> GrovePi.Button.add_listenter(pid, :pressed, module)
+  {:ok, _}
+
+  iex> GrovePi.Button.add_listenter(pid, :released, module)
+  {:ok, _}
+  """
+
+  def start_link(grove_pid, pin) do
+    Supervisor.start_link(__MODULE__, [grove_pid, pin])
+  end
+
+  def init([grove_pid, pin]) do
+    children = [
+      worker(GrovePi.Button.Handler, [self(), grove_pid, pin])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+
+  def start_loop(sup_pid, handler_pid) do
+    Supervisor.start_child(sup_pid, worker(GrovePi.Button.Loop, [handler_pid]))
+  end
+
+  defmodule Loop do
+    def start_link(handler_pid) do
+      Task.start_link(fn -> loop(handler_pid) end)
+    end
+
+    def loop(handler_pid) do
+      :timer.sleep 1000
+      GrovePi.Button.Handler.notify_state(handler_pid)
+      loop(handler_pid)
+    end
+
+  end
+
+  defmodule Handler do
+    use GenServer
+    defmodule State do
+      defstruct [:pin, :registry, :grove, :sup_pid, :value]
+    end
+
+    def start_link(sup_pid, grove, pin) do
+      GenServer.start_link(__MODULE__, [sup_pid, grove, pin])
+    end
+
+    def init([sup_pid, grove, pin]) do
+      #{:ok, pid} = Registry.start_link(:duplicate)
+      state = %State{pin: pin, registry: nil, grove: grove, sup_pid: sup_pid}
+      handler_pid = self()
+      Task.start fn -> GrovePi.Button.start_loop(sup_pid, handler_pid) end
+      {:ok, state}
+    end
+
+    def notify_state(pid) do
+      GenServer.cast(pid, {:notify_state})
+    end
+
+    def notify_change(1, 0), do: IO.puts "released"
+    def notify_change(0, 1), do: IO.puts "pressed"
+    def notify_change(_, _), do: :ok
+
+    def handle_cast({:notify_state}, state) do
+      new_state = update_value(state)
+      notify_change(state.value, new_state.value)
+      {:noreply, new_state}
+    end
+
+    def read(pid) do
+      GenServer.call(pid, {:read})
+    end
+
+    def handle_call({:read}, _from, state) do
+      new_state = update_value(state)
+      {:reply, new_state.value, new_state}
+    end
+
+    def update_value(state) do
+      value = GrovePi.Digital.read(state.grove, state.pin)
+      %{state | value: value}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GrovePi.Mixfile do
   use Mix.Project
 
   @name      "GrovePi"
-  @version   "0.1.0"
+  @version   "0.1.1"
   @github    "https://github.com/fhunleth/grovepi"
   @homepage  @github
 


### PR DESCRIPTION
This is just an idea, but I need a registery which I think I can use one
registery with more than one button to dispatch to. I can register with
a key of `{:pressed, pin_num}` or `{:released, pin_num}` and have a nive
named registery. Each pin would then have its own loop and handler.

Amos King @adkron <amos@binarynoggin.com>
Todd Pickell @tapickell <todd@tap-software.com>

I'm really looking for feedback. Please don't merge