### PR TITLE
Default I2C to use elixir_ale module

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,3 +1,0 @@
-use Mix.Config
-
-config :grovepi, :i2c, I2c

--- a/lib/grovepi.ex
+++ b/lib/grovepi.ex
@@ -14,7 +14,7 @@ defmodule GrovePi do
   """
 
   @grovepi_address 0x04
-  @i2c Application.get_env(:grovepi, :i2c)
+  use GrovePi.I2C
 
   @doc """
   """

--- a/lib/grovepi/rgblcd.ex
+++ b/lib/grovepi/rgblcd.ex
@@ -4,7 +4,7 @@ defmodule GrovePi.RGBLCD do
 
   @rgb_address  0x62
   @text_address 0x3e
-  @i2c Application.get_env(:grovepi, :i2c)
+  use GrovePi.I2C
 
   # Currently this is directly translated from Python
   # NOTE: Review datasheet, since this does not seem like

--- a/lib/grovepi/ultrasonic.ex
+++ b/lib/grovepi/ultrasonic.ex
@@ -12,7 +12,7 @@ defmodule GrovePi.Ultrasonic do
 
   """
 
-  @i2c Application.get_env(:grovepi, :i2c)
+  use GrovePi.I2C
 
   def read_distance(pid, pin) do
     :ok = @i2c.write(pid, <<7, pin, 0, 0>>)

--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -1,6 +1,12 @@
 defmodule GrovePi.I2C do
   use GenServer
 
+  defmacro __using__(_) do
+    quote do
+      @i2c Application.get_env(:grovepi, :i2c, I2c)
+    end
+  end
+
   @type i2c_address :: 0..127
 
   defmodule State do


### PR DESCRIPTION
This will allow clients to not have to configure their applications if
they want to use the default of elixir_ale for I2C communication. The
default has also moved into the GrovePi.I2C module so that the default
is configured in one location.

Amos King @adkron <amos@binarynoggin.com>