### PR TITLE
Eliminate boiler plate setup from component tests

### DIFF
--- a/test/button_test.exs
+++ b/test/button_test.exs
@@ -1,75 +1,61 @@
 defmodule GrovePi.ButtonTest do
-  use ExUnit.Case, async: true
+  use ComponentTestCase, async: true
   @pressed <<1>>
   @released <<0>>
-  @pin 5
-  @moduletag report: [:prefix, :board, :poll_interval]
 
-  def start_button(prefix, poll_interval) do
-    with {:ok, _} <- GrovePi.Supervisor.start_link(0x40, prefix),
-         {:ok, _} <- GrovePi.Button.start_link(@pin,
-                                          poll_interval: poll_interval,
-                                          prefix: prefix,
-                                        ),
-    do: :ok
+  setup %{prefix: prefix} = tags do
+    poll_interval = Map.get(tags, :poll_interval, 1)
+
+    {:ok, _} = GrovePi.Button.start_link(@pin,
+                                         poll_interval: poll_interval,
+                                         prefix: prefix,
+                                       )
+
+      {:ok, tags}
   end
 
-  describe "default button" do
-    setup tags do
-      prefix = String.to_atom(Time.to_string(Time.utc_now))
-      board = GrovePi.Board.i2c_name(prefix)
-      poll_interval = Map.get(tags, :poll_interval, 1)
+  test "registering for a pressed event receives pressed messages",
+  %{prefix: prefix, board: board} do
+    GrovePi.Button.subscribe(@pin, :pressed, prefix)
+    GrovePi.I2C.add_responses(board, [@pressed])
 
-      start_button(prefix, poll_interval)
+    assert_receive {@pin, :pressed}, 300
+  end
 
-      GrovePi.I2C.reset(board)
+  test "registering for a released event receives released messages",
+  %{prefix: prefix, board: board} do
+    GrovePi.Button.subscribe(@pin, :released, prefix)
+    GrovePi.I2C.add_responses(board, [@pressed, @released])
 
-      {:ok, [prefix: prefix, board: board]}
-    end
+    assert_receive {@pin, :released}, 300
+  end
 
-    test "registering for a pressed event receives pressed messages",
-      %{prefix: prefix, board: board} do
-      GrovePi.Button.subscribe(@pin, :pressed, prefix)
-      GrovePi.I2C.add_responses(board, [@pressed])
+  @tag :capture_log
+  test "recovers from I2C error",
+  %{prefix: prefix, board: board} do
+    GrovePi.Button.subscribe(@pin, :released, prefix)
+    GrovePi.I2C.add_responses(board, [
+                                {:error, :i2c_write_failed},
+                                @pressed,
+                                @released,
+                              ])
 
-      assert_receive {@pin, :pressed}, 300
-    end
+    assert_receive {@pin, :released}, 300
+  end
 
-    test "registering for a released event receives released messages",
-      %{prefix: prefix, board: board} do
-      GrovePi.Button.subscribe(@pin, :released, prefix)
-      GrovePi.I2C.add_responses(board, [@pressed, @released])
+  @tag poll_interval: 1_000_000
+  test "reading notifies subscribers",
+  %{prefix: prefix, board: board} do
+    GrovePi.Button.subscribe(@pin, :released, prefix)
+    GrovePi.Button.subscribe(@pin, :pressed, prefix)
+    GrovePi.I2C.add_responses(board, [@pressed, @released, @pressed])
 
-      assert_receive {@pin, :released}, 300
-    end
+    GrovePi.Button.read(@pin, prefix)
 
-    @tag :capture_log
-    test "recovers from I2C error",
-      %{prefix: prefix, board: board} do
-      GrovePi.Button.subscribe(@pin, :released, prefix)
-      GrovePi.I2C.add_responses(board, [
-                  {:error, :i2c_write_failed},
-                  @pressed,
-                  @released,
-                ])
+    assert_receive {@pin, :pressed}, 10
 
-      assert_receive {@pin, :released}, 300
-    end
+    GrovePi.Button.read(@pin, prefix)
 
-    @tag poll_interval: 1_000_000
-    test "reading notifies subscribers",
-      %{prefix: prefix, board: board} do
-      GrovePi.Button.subscribe(@pin, :released, prefix)
-      GrovePi.Button.subscribe(@pin, :pressed, prefix)
-      GrovePi.I2C.add_responses(board, [@pressed, @released, @pressed])
-
-      GrovePi.Button.read(@pin, prefix)
-
-      assert_receive {@pin, :pressed}, 10
-
-      GrovePi.Button.read(@pin, prefix)
-
-      assert_receive {@pin, :released}, 10
-    end
+    assert_receive {@pin, :released}, 10
   end
 end

--- a/test/buzzer_test.exs
+++ b/test/buzzer_test.exs
@@ -1,25 +1,11 @@
 defmodule GrovePi.BuzzerTest do
-  use ExUnit.Case, async: true
+  use ComponentTestCase, async: true
   @on 1
   @off 0
-  @pin 5
-  @moduletag report: [:prefix, :board]
 
-  def start_buzzer(prefix) do
-    with {:ok, _} <- GrovePi.Supervisor.start_link(0x40, prefix),
-         {:ok, _} = GrovePi.Buzzer.start_link(@pin, prefix: prefix),
-    do: :ok
-  end
-
-  setup do
-    prefix = String.to_atom(Time.to_string(Time.utc_now))
-    board = GrovePi.Board.i2c_name(prefix)
-
-    start_buzzer(prefix)
-
-    GrovePi.I2C.reset(board)
-
-    {:ok, [prefix: prefix, board: board]}
+  setup %{prefix: prefix} = tags do
+    {:ok, _} = GrovePi.Buzzer.start_link(@pin, prefix: prefix)
+    {:ok, tags}
   end
 
   test "buzzes for one second by default",

--- a/test/dht_test.exs
+++ b/test/dht_test.exs
@@ -1,23 +1,9 @@
 defmodule GrovePi.DHTTest do
-  use ExUnit.Case, async: true
-  @pin 5
-  @moduletag report: [:prefix, :board]
+  use ComponentTestCase, async: true
 
-  def start_dht(prefix) do
-    with {:ok, _} <- GrovePi.Supervisor.start_link(0x40, prefix),
-         {:ok, _} = GrovePi.DHT.start_link(@pin, prefix: prefix),
-    do: :ok
-  end
-
-  setup do
-    prefix = String.to_atom(Time.to_string(Time.utc_now))
-    board = GrovePi.Board.i2c_name(prefix)
-
-    start_dht(prefix)
-
-    GrovePi.I2C.reset(board)
-
-    {:ok, [prefix: prefix, board: board]}
+  setup %{prefix: prefix} = tags do
+    {:ok, _} = GrovePi.DHT.start_link(@pin, prefix: prefix)
+    {:ok, tags}
   end
 
   test "gets temp and humidity",

--- a/test/grovepi_test.exs
+++ b/test/grovepi_test.exs
@@ -1,15 +1,5 @@
 defmodule GrovePi.GrovePiTest do
-  use ExUnit.Case, async: true
-  @moduletag report: [:prefix, :board]
-
-  setup do
-    prefix = String.to_atom(Time.to_string(Time.utc_now))
-    board = GrovePi.Board.i2c_name(prefix)
-
-    GrovePi.Board.start_link(0x40, prefix)
-    GrovePi.I2C.reset(board)
-    {:ok, [prefix: prefix, board: board]}
-  end
+  use ComponentTestCase, async: true
 
   test "getting version works",
     %{prefix: prefix, board: board} do

--- a/test/support/component_test_case.exs
+++ b/test/support/component_test_case.exs
@@ -1,0 +1,23 @@
+defmodule ComponentTestCase do
+  use ExUnit.CaseTemplate
+  using do
+    quote do
+      @pin 5
+      @moduletag report: [:prefix, :board]
+    end
+  end
+
+  setup tags do
+    prefix = String.to_atom(Time.to_string(Time.utc_now))
+    board = GrovePi.Board.i2c_name(prefix)
+
+    {:ok, _} = GrovePi.Supervisor.start_link(0x40, prefix)
+
+    GrovePi.I2C.reset(board)
+
+    tags = Map.put(tags, :prefix, prefix)
+    tags = Map.put(tags, :board, board)
+    {:ok, tags}
+  end
+end
+

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,4 @@
 ExUnit.start()
 Application.start(:logger)
+
+Code.require_file "test/support/component_test_case.exs"

--- a/test/ultrasonic_test.exs
+++ b/test/ultrasonic_test.exs
@@ -1,23 +1,9 @@
 defmodule GrovePi.UltrasonicTest do
-  use ExUnit.Case, async: true
-  @pin 5
-  @moduletag report: [:prefix, :board]
+  use ComponentTestCase, async: true
 
-  def start_ultrasonic(prefix) do
-    with {:ok, _} <- GrovePi.Supervisor.start_link(0x40, prefix),
-         {:ok, _} = GrovePi.Ultrasonic.start_link(@pin, prefix: prefix),
-    do: :ok
-  end
-
-  setup do
-    prefix = String.to_atom(Time.to_string(Time.utc_now))
-    board = GrovePi.Board.i2c_name(prefix)
-
-    start_ultrasonic(prefix)
-
-    GrovePi.I2C.reset(board)
-
-    {:ok, [prefix: prefix, board: board]}
+  setup %{prefix: prefix} = tags do
+    {:ok, _} = GrovePi.Ultrasonic.start_link(@pin, prefix: prefix)
+    {:ok, tags}
   end
 
   test "gets distance",


### PR DESCRIPTION
In order to remove the boiler plate startup code I created a test case
just for component processes. It still requires a little boiler plate,
but not like what was there in the first place. I didn't want to go to
far with elimination and hide too mush setup from the test.

Amos King @adkron <amos@binarynoggin.com>