### PR TITLE
Add support for user defined triggers and data

### DIFF
--- a/examples/alarm/lib/alarm.ex
+++ b/examples/alarm/lib/alarm.ex
@@ -39,7 +39,7 @@ defmodule Alarm do
       {:ok, state}
     end
 
-    def handle_info({_, :pressed}, state) do
+    def handle_info({_, :pressed, _}, state) do
       IO.puts("Alert!!!!")
 
       # Sound the alarm, but only for a second

--- a/lib/grovepi/button.ex
+++ b/lib/grovepi/button.ex
@@ -35,6 +35,13 @@ defmodule GrovePi.Button do
     defstruct [:pin, :trigger_state, :poll_interval, :prefix, :trigger]
   end
 
+  @doc """
+  # Options
+
+    * `:poll_interval` - The time in ms between polling for state. Default: `100`
+    * `:trigger` - This is used to pass in a trigger to use for triggering events. Default: `GrovePi.Button.DefaultTrigger`
+  """
+
   @spec start_link(GrovePi.pin) :: Supervisor.on_start
   def start_link(pin, opts \\ []) do
     poll_interval = Keyword.get(opts, :poll_interval, @poll_interval)

--- a/lib/grovepi/button/default_trigger.ex
+++ b/lib/grovepi/button/default_trigger.ex
@@ -1,0 +1,17 @@
+defmodule GrovePi.Button.DefaultTrigger do
+  defmodule State do
+    defstruct value: 0
+  end
+
+  def initial_state do
+    %State{}
+  end
+
+  def update(value, %State{value: value} = state), do: {:ok, state}
+  def update(new_value, state) do
+    {event(new_value), %{state | value: new_value}}
+  end
+
+  defp event(0), do: :released
+  defp event(1), do: :pressed
+end

--- a/lib/grovepi/button/default_trigger.ex
+++ b/lib/grovepi/button/default_trigger.ex
@@ -1,5 +1,28 @@
 defmodule GrovePi.Button.DefaultTrigger do
+  @moduledoc """
+  This is the default triggering mechanism for Button events. Events
+  are either `pressed` or `released` and include the trigger state.
+  The trigger state for the default trigger is a struct containing
+  a `value` property.
+
+  iex> GrovePi.Button.DefaultTrigger.initial_state
+  %GrovePi.Button.DefaultTrigger.State{value: 0}
+
+  iex> GrovePi.Button.DefaultTrigger.update(0, %{value: 0})
+  {:ok, %{value: 0}}
+
+  iex> GrovePi.Button.DefaultTrigger.update(1, %{value: 1})
+  {:ok, %{value: 1}}
+
+  iex> GrovePi.Button.DefaultTrigger.update(0, %{value: 1})
+  {:released, %{value: 0}}
+
+  iex> GrovePi.Button.DefaultTrigger.update(1, %{value: 0})
+  {:pressed, %{value: 1}}
+  """
+
   defmodule State do
+    @moduledoc false
     defstruct value: 0
   end
 
@@ -7,7 +30,7 @@ defmodule GrovePi.Button.DefaultTrigger do
     %State{}
   end
 
-  def update(value, %State{value: value} = state), do: {:ok, state}
+  def update(value, %{value: value} = state), do: {:ok, state}
   def update(new_value, state) do
     {event(new_value), %{state | value: new_value}}
   end

--- a/lib/grovepi/button/default_trigger.ex
+++ b/lib/grovepi/button/default_trigger.ex
@@ -5,20 +5,22 @@ defmodule GrovePi.Button.DefaultTrigger do
   The trigger state for the default trigger is a struct containing
   a `value` property.
 
-  iex> GrovePi.Button.DefaultTrigger.initial_state
-  %GrovePi.Button.DefaultTrigger.State{value: 0}
+  ## Examples
 
-  iex> GrovePi.Button.DefaultTrigger.update(0, %{value: 0})
-  {:ok, %{value: 0}}
+      iex> GrovePi.Button.DefaultTrigger.initial_state
+      %GrovePi.Button.DefaultTrigger.State{value: 0}
 
-  iex> GrovePi.Button.DefaultTrigger.update(1, %{value: 1})
-  {:ok, %{value: 1}}
+      iex> GrovePi.Button.DefaultTrigger.update(0, %{value: 0})
+      {:ok, %{value: 0}}
 
-  iex> GrovePi.Button.DefaultTrigger.update(0, %{value: 1})
-  {:released, %{value: 0}}
+      iex> GrovePi.Button.DefaultTrigger.update(1, %{value: 1})
+      {:ok, %{value: 1}}
 
-  iex> GrovePi.Button.DefaultTrigger.update(1, %{value: 0})
-  {:pressed, %{value: 1}}
+      iex> GrovePi.Button.DefaultTrigger.update(0, %{value: 1})
+      {:released, %{value: 0}}
+
+      iex> GrovePi.Button.DefaultTrigger.update(1, %{value: 0})
+      {:pressed, %{value: 1}}
   """
 
   defmodule State do

--- a/lib/grovepi/button/default_trigger.ex
+++ b/lib/grovepi/button/default_trigger.ex
@@ -6,7 +6,6 @@ defmodule GrovePi.Button.DefaultTrigger do
   a `value` property.
 
   ## Examples
-
       iex> GrovePi.Button.DefaultTrigger.initial_state
       %GrovePi.Button.DefaultTrigger.State{value: 0}
 

--- a/lib/grovepi/registry/subscriber.ex
+++ b/lib/grovepi/registry/subscriber.ex
@@ -1,6 +1,11 @@
 defmodule GrovePi.Registry.Subscriber do
   @moduledoc false
 
+  @type event :: atom
+  @type package :: any
+  @type registration :: {GrovePi.pin, event}
+  @type message :: {GrovePi.pin, event, package}
+
   @spec start_link(Registry.registry) :: Supervisor.on_start
   def start_link(prefix, opts \\ []) do
     opts = Keyword.put(opts, :id, :subscriber_registry)
@@ -8,13 +13,13 @@ defmodule GrovePi.Registry.Subscriber do
   end
 
   @spec notify_change(atom, GrovePi.Buttons.message) :: :ok
-  def notify_change(prefix, message) do
-    Registry.dispatch(registry(prefix), message, fn(listeners) ->
+  def notify_change(prefix, {pin, event, _} = message) do
+    Registry.dispatch(registry(prefix), {pin, event}, fn(listeners) ->
       for {pid, :ok} <- listeners, do: send(pid, message)
     end)
   end
 
-  @spec subscribe(atom, GrovePi.Buttons.message) :: :ok | {:error, {:already_registered, pid}}
+  @spec subscribe(atom, registration) :: :ok | {:error, {:already_registered, pid}}
   def subscribe(prefix, message) do
     Registry.register(registry(prefix), message, :ok)
   end

--- a/test/button_test.exs
+++ b/test/button_test.exs
@@ -19,7 +19,7 @@ defmodule GrovePi.ButtonTest do
     GrovePi.Button.subscribe(@pin, :pressed, prefix)
     GrovePi.I2C.add_responses(board, [@pressed])
 
-    assert_receive {@pin, :pressed}, 300
+    assert_receive {@pin, :pressed, _}, 300
   end
 
   test "registering for a released event receives released messages",
@@ -27,7 +27,7 @@ defmodule GrovePi.ButtonTest do
     GrovePi.Button.subscribe(@pin, :released, prefix)
     GrovePi.I2C.add_responses(board, [@pressed, @released])
 
-    assert_receive {@pin, :released}, 300
+    assert_receive {@pin, :released, _}, 300
   end
 
   @tag :capture_log
@@ -40,7 +40,7 @@ defmodule GrovePi.ButtonTest do
                                 @released,
                               ])
 
-    assert_receive {@pin, :released}, 300
+    assert_receive {@pin, :released, _}, 300
   end
 
   @tag poll_interval: 1_000_000
@@ -52,10 +52,10 @@ defmodule GrovePi.ButtonTest do
 
     GrovePi.Button.read(@pin, prefix)
 
-    assert_receive {@pin, :pressed}, 10
+    assert_receive {@pin, :pressed, _}, 10
 
     GrovePi.Button.read(@pin, prefix)
 
-    assert_receive {@pin, :released}, 10
+    assert_receive {@pin, :released, _}, 10
   end
 end

--- a/test/grovepi/button/default_trigger_test.exs
+++ b/test/grovepi/button/default_trigger_test.exs
@@ -1,31 +1,4 @@
 defmodule GrovePi.Button.DefaultTriggerTest do
   use ExUnit.Case, async: true
-  alias GrovePi.Button.DefaultTrigger
-  alias GrovePi.Button.DefaultTrigger.State
-
-  test "initial state is released" do
-    assert %State{value: 0} == DefaultTrigger.initial_state
-  end
-
-  test "update with same value" do
-    released_state = %State{value: 0}
-    assert {:ok, released_state} == DefaultTrigger.update(0, released_state)
-
-    pressed_state = %State{value: 1}
-    assert {:ok, pressed_state} == DefaultTrigger.update(1, pressed_state)
-  end
-
-  test "return pressed event" do
-    released_state = %State{value: 0}
-    pressed_state = %State{value: 1}
-
-    assert {:pressed, pressed_state} == DefaultTrigger.update(1, released_state)
-  end
-
-  test "return released event" do
-    released_state = %State{value: 0}
-    pressed_state = %State{value: 1}
-
-    assert {:released, released_state} == DefaultTrigger.update(0, pressed_state)
-  end
+  doctest GrovePi.Button.DefaultTrigger
 end

--- a/test/grovepi/button/default_trigger_test.exs
+++ b/test/grovepi/button/default_trigger_test.exs
@@ -1,0 +1,31 @@
+defmodule GrovePi.Button.DefaultTriggerTest do
+  use ExUnit.Case, async: true
+  alias GrovePi.Button.DefaultTrigger
+  alias GrovePi.Button.DefaultTrigger.State
+
+  test "initial state is released" do
+    assert %State{value: 0} == DefaultTrigger.initial_state
+  end
+
+  test "update with same value" do
+    released_state = %State{value: 0}
+    assert {:ok, released_state} == DefaultTrigger.update(0, released_state)
+
+    pressed_state = %State{value: 1}
+    assert {:ok, pressed_state} == DefaultTrigger.update(1, pressed_state)
+  end
+
+  test "return pressed event" do
+    released_state = %State{value: 0}
+    pressed_state = %State{value: 1}
+
+    assert {:pressed, pressed_state} == DefaultTrigger.update(1, released_state)
+  end
+
+  test "return released event" do
+    released_state = %State{value: 0}
+    pressed_state = %State{value: 1}
+
+    assert {:released, released_state} == DefaultTrigger.update(0, pressed_state)
+  end
+end

--- a/test/subscriber_test.exs
+++ b/test/subscriber_test.exs
@@ -1,0 +1,13 @@
+defmodule GrovePi.Registry.SubscriberTest do
+  use ComponentTestCase, async: true
+  alias GrovePi.Registry.Subscriber
+
+  test "subscribing then gets messages sent with data on notification",
+  %{prefix: prefix} do
+    {:ok, _} = Subscriber.subscribe(prefix, {@pin, :event})
+
+    Subscriber.notify_change(prefix, {@pin, :event, :my_data})
+
+    assert_receive {@pin, :event, :my_data}, 10
+  end
+end


### PR DESCRIPTION
This allows users to send in their own triggers so they can customize
the data and the way a trigger behaves. This will become more important
with sound.

Amos King @adkron <amos@binarynoggin.com>