### PR TITLE
Add Sound trigger

### DIFF
--- a/lib/grovepi/button.ex
+++ b/lib/grovepi/button.ex
@@ -3,7 +3,7 @@ defmodule GrovePi.Button do
 
   @moduledoc """
   Listen for events from a GrovePi button. There are two types of
-  events; pressed and released. When registering for an event the button
+  events by defualt; pressed and released. When registering for an event the button
   will then send a message of `{pin, :pressed, {value: 1}` or
   `{pin, :released, {value: 0}}`. The button works by polling
   `GrovePi.Digital` on the pin that you have registered to a button.

--- a/lib/grovepi/button.ex
+++ b/lib/grovepi/button.ex
@@ -1,5 +1,5 @@
 defmodule GrovePi.Button do
-  use GenServer
+  use GrovePi.Poller, default_trigger: GrovePi.Button.DefaultTrigger, read_type: GrovePi.Digital.level
 
   @moduledoc """
   Listen for events from a GrovePi button. There are two types of
@@ -19,94 +19,7 @@ defmodule GrovePi.Button do
   ```
   """
 
-  @type level :: 1 | 0
-  @type change :: {level, level}
-  @type event :: :pressed | :released
-
-  @poll_interval 100
-  @trigger GrovePi.Button.DefaultTrigger
-
-  alias GrovePi.Registry.Pin
-
-  alias GrovePi.Registry.Subscriber
-
-  defmodule State do
-    @moduledoc false
-    defstruct [:pin, :trigger_state, :poll_interval, :prefix, :trigger]
-  end
-
-  @doc """
-  # Options
-
-    * `:poll_interval` - The time in ms between polling for state. Default: `100`
-    * `:trigger` - This is used to pass in a trigger to use for triggering events. Default: `GrovePi.Button.DefaultTrigger`
-  """
-
-  @spec start_link(GrovePi.pin) :: Supervisor.on_start
-  def start_link(pin, opts \\ []) do
-    poll_interval = Keyword.get(opts, :poll_interval, @poll_interval)
-    trigger = Keyword.get(opts, :trigger, @trigger)
-    prefix = Keyword.get(opts, :prefix, Default)
-    opts = Keyword.put(opts, :name, Pin.name(prefix, pin))
-
-    GenServer.start_link(__MODULE__,
-      [pin, poll_interval, prefix, trigger],
-      opts
-      )
-  end
-
-  def init([pin, poll_interval, prefix, trigger]) do
-    state = %State{
-      pin: pin,
-      poll_interval: poll_interval,
-      prefix: prefix,
-      trigger: trigger,
-      trigger_state: trigger.initial_state,
-      }
-
-    schedule_poll(state)
-
-    {:ok, state}
-  end
-
-  def schedule_poll(%State{poll_interval: poll_interval}) do
-    Process.send_after(self(), :poll_button, poll_interval)
-  end
-
-  @spec read(GrovePi.pin, atom) :: level
-  def read(pin, prefix \\ Default) do
-    GenServer.call(Pin.name(prefix, pin), :read)
-  end
-
-  @spec subscribe(GrovePi.pin, event, atom) :: level
-  def subscribe(pin, event, prefix \\ Default) do
-    Subscriber.subscribe(prefix, {pin, event})
-  end
-
-  def handle_call(:read, _from, state) do
-    {value, new_state} = update_value(state)
-    {:reply, value, new_state}
-  end
-
-  def handle_info(:poll_button, state) do
-    {_, new_state} = update_value(state)
-    schedule_poll(state)
-    {:noreply, new_state}
-  end
-
-  @spec update_value(State) ::State
-  defp update_value(state) do
-    with value <- GrovePi.Digital.read(state.prefix, state.pin),
-         trigger = {_, trigger_state} <- state.trigger.update(value, state.trigger_state),
-         :ok <- notify(trigger, state.prefix, state.pin),
-         do: {value, %{state | trigger_state: trigger_state}}
-  end
-
-  defp notify({:ok, _}, _, _) do
-    :ok
-  end
-
-  defp notify({event, trigger_state}, prefix, pin) do
-    Subscriber.notify_change(prefix, {pin, event, trigger_state})
+  def read_value(prefix, pin) do
+    GrovePi.Digital.read(prefix, pin)
   end
 end

--- a/lib/grovepi/button/default_trigger.ex
+++ b/lib/grovepi/button/default_trigger.ex
@@ -1,4 +1,6 @@
 defmodule GrovePi.Button.DefaultTrigger do
+  @behaviour GrovePi.Trigger
+
   @moduledoc """
   This is the default triggering mechanism for Button events. Events
   are either `pressed` or `released` and include the trigger state.
@@ -6,8 +8,8 @@ defmodule GrovePi.Button.DefaultTrigger do
   a `value` property.
 
   ## Examples
-      iex> GrovePi.Button.DefaultTrigger.initial_state
-      %GrovePi.Button.DefaultTrigger.State{value: 0}
+      iex> GrovePi.Button.DefaultTrigger.init([])
+      {:ok, %GrovePi.Button.DefaultTrigger.State{value: 0}}
 
       iex> GrovePi.Button.DefaultTrigger.update(0, %{value: 0})
       {:ok, %{value: 0}}
@@ -27,8 +29,8 @@ defmodule GrovePi.Button.DefaultTrigger do
     defstruct value: 0
   end
 
-  def initial_state do
-    %State{}
+  def init(_) do
+    {:ok, %State{}}
   end
 
   def update(value, %{value: value} = state), do: {:ok, state}

--- a/lib/grovepi/poller.ex
+++ b/lib/grovepi/poller.ex
@@ -1,0 +1,98 @@
+defmodule GrovePi.Poller do
+  @callback read_value(atom, GrovePi.pin) :: any
+
+  defmacro __using__([default_trigger: default_trigger, read_type: read_type]) do
+    quote location: :keep do
+      use GenServer
+      @behaviour GrovePi.Poller
+
+      @poll_interval 100
+
+      @type event :: atom
+
+      alias GrovePi.Registry.Pin
+
+      alias GrovePi.Registry.Subscriber
+
+      defmodule State do
+        @moduledoc false
+        defstruct [:pin, :trigger_state, :poll_interval, :prefix, :trigger]
+      end
+
+      @doc """
+      # Options
+
+      * `:poll_interval` - The time in ms between polling for state. Default: `100`
+      * `:trigger` - This is used to pass in a trigger to use for triggering events. Default: `GrovePi.Button.DefaultTrigger`
+      """
+
+      @spec start_link(GrovePi.pin) :: Supervisor.on_start
+      def start_link(pin, opts \\ []) do
+        poll_interval = Keyword.get(opts, :poll_interval, @poll_interval)
+        trigger = Keyword.get(opts, :trigger, unquote(default_trigger))
+        prefix = Keyword.get(opts, :prefix, Default)
+        opts = Keyword.put(opts, :name, Pin.name(prefix, pin))
+
+        GenServer.start_link(__MODULE__,
+                             [pin, poll_interval, prefix, trigger],
+                             opts
+                           )
+      end
+
+      def init([pin, poll_interval, prefix, trigger]) do
+        state = %State{
+          pin: pin,
+          poll_interval: poll_interval,
+          prefix: prefix,
+          trigger: trigger,
+          trigger_state: trigger.initial_state,
+        }
+
+        schedule_poll(state)
+
+        {:ok, state}
+      end
+
+      def schedule_poll(%State{poll_interval: poll_interval}) do
+        Process.send_after(self(), :poll_button, poll_interval)
+      end
+
+      @spec read(GrovePi.pin, atom) :: unquote(read_type)
+      def read(pin, prefix \\ Default) do
+        GenServer.call(Pin.name(prefix, pin), :read)
+      end
+
+      @spec subscribe(GrovePi.pin, event, atom) :: {:ok, pid} | {:error, {:already_registered, pid}}
+      def subscribe(pin, event, prefix \\ Default) do
+        Subscriber.subscribe(prefix, {pin, event})
+      end
+
+      def handle_call(:read, _from, state) do
+        {value, new_state} = update_value(state)
+        {:reply, value, new_state}
+      end
+
+      def handle_info(:poll_button, state) do
+        {_, new_state} = update_value(state)
+        schedule_poll(state)
+        {:noreply, new_state}
+      end
+
+      @spec update_value(State) ::State
+      defp update_value(state) do
+        with value <- read_value(state.prefix, state.pin),
+        trigger = {_, trigger_state} <- state.trigger.update(value, state.trigger_state),
+        :ok <- notify(trigger, state.prefix, state.pin),
+        do: {value, %{state | trigger_state: trigger_state}}
+      end
+
+      defp notify({:ok, _}, _, _) do
+        :ok
+      end
+
+      defp notify({event, trigger_state}, prefix, pin) do
+        Subscriber.notify_change(prefix, {pin, event, trigger_state})
+      end
+    end
+  end
+end

--- a/lib/grovepi/sound.ex
+++ b/lib/grovepi/sound.ex
@@ -6,7 +6,7 @@ defmodule GrovePi.Sound do
   events by default; loud and quiet. When registering for an event the sound
   will then send a message of `{pin, :loud, {value: 1, last_event: :loud}` or
   `{pin, :quiet, {value: 0, last_event: :quiet}}`. The sound works by polling
-  `GrovePi.Digital` on the pin that you have registered to a sound.
+  `GrovePi.Analog` on the pin that you have registered to a sound.
 
   Example usage:
   ```

--- a/lib/grovepi/sound.ex
+++ b/lib/grovepi/sound.ex
@@ -2,8 +2,8 @@ defmodule GrovePi.Sound do
   use GrovePi.Poller, default_trigger: GrovePi.Sound.HysteresisTrigger, read_type: GrovePi.Analog.adc_level
 
   @moduledoc """
-  Listen for events from a GrovePi sound. There are two types of
-  events; loud and quiet. When registering for an event the sound
+  Listen for events from a GrovePi sound module. There are two types of
+  events by default; loud and quiet. When registering for an event the sound
   will then send a message of `{pin, :loud, {value: 1, last_event: :loud}` or
   `{pin, :quiet, {value: 0, last_event: :quiet}}`. The sound works by polling
   `GrovePi.Digital` on the pin that you have registered to a sound.

--- a/lib/grovepi/sound.ex
+++ b/lib/grovepi/sound.ex
@@ -1,0 +1,112 @@
+defmodule GrovePi.Sound do
+  use GenServer
+
+  @moduledoc """
+  Listen for events from a GrovePi sound. There are two types of
+  events; loud and quiet. When registering for an event the sound
+  will then send a message of `{pin, :loud, {value: 1, last_event: :loud}` or
+  `{pin, :quiet, {value: 0, last_event: :quiet}}`. The sound works by polling
+  `GrovePi.Digital` on the pin that you have registered to a sound.
+
+  Example usage:
+  ```
+  iex> {:ok, sound}=GrovePi.Sound.start_link(3)
+  :ok
+  iex> GrovePi.Sound.subscribe(3, :loud)
+  :ok
+  iex> GrovePi.Sound.subscribe(3, :quiet)
+  :ok
+  ```
+  """
+
+  @type level :: 1 | 0
+  @type change :: {level, level}
+  @type event :: :loud | :quiet
+
+  @poll_interval 100
+  @trigger GrovePi.Sound.HysteresisTrigger
+
+  alias GrovePi.Registry.Pin
+
+  alias GrovePi.Registry.Subscriber
+
+  defmodule State do
+    @moduledoc false
+    defstruct [:pin, :trigger_state, :poll_interval, :prefix, :trigger]
+  end
+
+  @doc """
+  # Options
+
+    * `:poll_interval` - The time in ms between polling for state. Default: `100`
+    * `:trigger` - This is used to pass in a trigger to use for triggering events. Default: `GrovePi.Sound.HyseresisTrigger`
+  """
+
+  @spec start_link(GrovePi.pin) :: Supervisor.on_start
+  def start_link(pin, opts \\ []) do
+    poll_interval = Keyword.get(opts, :poll_interval, @poll_interval)
+    trigger = Keyword.get(opts, :trigger, @trigger)
+    prefix = Keyword.get(opts, :prefix, Default)
+    opts = Keyword.put(opts, :name, Pin.name(prefix, pin))
+
+    GenServer.start_link(__MODULE__,
+      [pin, poll_interval, prefix, trigger],
+      opts
+      )
+  end
+
+  def init([pin, poll_interval, prefix, trigger]) do
+    state = %State{
+      pin: pin,
+      poll_interval: poll_interval,
+      prefix: prefix,
+      trigger: trigger,
+      trigger_state: trigger.initial_state,
+      }
+
+    schedule_poll(state)
+
+    {:ok, state}
+  end
+
+  def schedule_poll(%State{poll_interval: poll_interval}) do
+    Process.send_after(self(), :poll_sound, poll_interval)
+  end
+
+  @spec read(GrovePi.pin, atom) :: level
+  def read(pin, prefix \\ Default) do
+    GenServer.call(Pin.name(prefix, pin), :read)
+  end
+
+  @spec subscribe(GrovePi.pin, event, atom) :: level
+  def subscribe(pin, event, prefix \\ Default) do
+    Subscriber.subscribe(prefix, {pin, event})
+  end
+
+  def handle_call(:read, _from, state) do
+    {value, new_state} = update_value(state)
+    {:reply, value, new_state}
+  end
+
+  def handle_info(:poll_sound, state) do
+    {_, new_state} = update_value(state)
+    schedule_poll(state)
+    {:noreply, new_state}
+  end
+
+  @spec update_value(State) ::State
+  defp update_value(state) do
+    with value <- GrovePi.Analog.read(state.prefix, state.pin),
+         trigger = {_, trigger_state} <- state.trigger.update(value, state.trigger_state),
+         :ok <- notify(trigger, state.prefix, state.pin),
+         do: {value, %{state | trigger_state: trigger_state}}
+  end
+
+  defp notify({:ok, _}, _, _) do
+    :ok
+  end
+
+  defp notify({event, trigger_state}, prefix, pin) do
+    Subscriber.notify_change(prefix, {pin, event, trigger_state})
+  end
+end

--- a/lib/grovepi/sound.ex
+++ b/lib/grovepi/sound.ex
@@ -1,5 +1,5 @@
 defmodule GrovePi.Sound do
-  use GenServer
+  use GrovePi.Poller, default_trigger: GrovePi.Sound.HysteresisTrigger, read_type: GrovePi.Analog.adc_level
 
   @moduledoc """
   Listen for events from a GrovePi sound. There are two types of
@@ -19,94 +19,7 @@ defmodule GrovePi.Sound do
   ```
   """
 
-  @type level :: 1 | 0
-  @type change :: {level, level}
-  @type event :: :loud | :quiet
-
-  @poll_interval 100
-  @trigger GrovePi.Sound.HysteresisTrigger
-
-  alias GrovePi.Registry.Pin
-
-  alias GrovePi.Registry.Subscriber
-
-  defmodule State do
-    @moduledoc false
-    defstruct [:pin, :trigger_state, :poll_interval, :prefix, :trigger]
-  end
-
-  @doc """
-  # Options
-
-    * `:poll_interval` - The time in ms between polling for state. Default: `100`
-    * `:trigger` - This is used to pass in a trigger to use for triggering events. Default: `GrovePi.Sound.HyseresisTrigger`
-  """
-
-  @spec start_link(GrovePi.pin) :: Supervisor.on_start
-  def start_link(pin, opts \\ []) do
-    poll_interval = Keyword.get(opts, :poll_interval, @poll_interval)
-    trigger = Keyword.get(opts, :trigger, @trigger)
-    prefix = Keyword.get(opts, :prefix, Default)
-    opts = Keyword.put(opts, :name, Pin.name(prefix, pin))
-
-    GenServer.start_link(__MODULE__,
-      [pin, poll_interval, prefix, trigger],
-      opts
-      )
-  end
-
-  def init([pin, poll_interval, prefix, trigger]) do
-    state = %State{
-      pin: pin,
-      poll_interval: poll_interval,
-      prefix: prefix,
-      trigger: trigger,
-      trigger_state: trigger.initial_state,
-      }
-
-    schedule_poll(state)
-
-    {:ok, state}
-  end
-
-  def schedule_poll(%State{poll_interval: poll_interval}) do
-    Process.send_after(self(), :poll_sound, poll_interval)
-  end
-
-  @spec read(GrovePi.pin, atom) :: level
-  def read(pin, prefix \\ Default) do
-    GenServer.call(Pin.name(prefix, pin), :read)
-  end
-
-  @spec subscribe(GrovePi.pin, event, atom) :: level
-  def subscribe(pin, event, prefix \\ Default) do
-    Subscriber.subscribe(prefix, {pin, event})
-  end
-
-  def handle_call(:read, _from, state) do
-    {value, new_state} = update_value(state)
-    {:reply, value, new_state}
-  end
-
-  def handle_info(:poll_sound, state) do
-    {_, new_state} = update_value(state)
-    schedule_poll(state)
-    {:noreply, new_state}
-  end
-
-  @spec update_value(State) ::State
-  defp update_value(state) do
-    with value <- GrovePi.Analog.read(state.prefix, state.pin),
-         trigger = {_, trigger_state} <- state.trigger.update(value, state.trigger_state),
-         :ok <- notify(trigger, state.prefix, state.pin),
-         do: {value, %{state | trigger_state: trigger_state}}
-  end
-
-  defp notify({:ok, _}, _, _) do
-    :ok
-  end
-
-  defp notify({event, trigger_state}, prefix, pin) do
-    Subscriber.notify_change(prefix, {pin, event, trigger_state})
+  def read_value(prefix, pin) do
+    GrovePi.Analog.read(prefix, pin)
   end
 end

--- a/lib/grovepi/sound.ex
+++ b/lib/grovepi/sound.ex
@@ -4,8 +4,8 @@ defmodule GrovePi.Sound do
   @moduledoc """
   Listen for events from a GrovePi sound module. There are two types of
   events by default; loud and quiet. When registering for an event the sound
-  will then send a message of `{pin, :loud, {value: 1, last_event: :loud}` or
-  `{pin, :quiet, {value: 0, last_event: :quiet}}`. The sound works by polling
+  will then send a message of `{pin, :loud, _trigger_date}` or
+  `{pin, :quiet, _trigger_data}`. The sound works by polling
   `GrovePi.Analog` on the pin that you have registered to a sound.
 
   Example usage:

--- a/lib/grovepi/sound/hysteresis_trigger.ex
+++ b/lib/grovepi/sound/hysteresis_trigger.ex
@@ -88,19 +88,11 @@ defmodule GrovePi.Sound.HysteresisTrigger do
     {:ok, %State{high_threshold: high_threshold, low_threshold: low_threshold}}
   end
 
-  def update(new_value, %{fireable: :any, low_threshold: low_threshold} = state) when new_value < low_threshold do
+  def update(new_value, %{fireable: fireable, low_threshold: low_threshold} = state) when new_value < low_threshold and fireable != :loud do
     {:quiet, %{state | value: new_value, fireable: :loud}}
   end
 
-  def update(new_value, %{fireable: :any, high_threshold: high_threshold} = state) when new_value > high_threshold do
-    {:loud, %{state | value: new_value, fireable: :quiet}}
-  end
-
-  def update(new_value, %{fireable: :quiet, low_threshold: low_threshold} = state) when new_value < low_threshold do
-    {:quiet, %{state | value: new_value, fireable: :loud}}
-  end
-
-  def update(new_value, %{fireable: :loud, high_threshold: high_threshold} = state) when new_value > high_threshold do
+  def update(new_value, %{fireable: fireable, high_threshold: high_threshold} = state) when new_value > high_threshold and fireable != :quiet do
     {:loud, %{state | value: new_value, fireable: :quiet}}
   end
 

--- a/lib/grovepi/sound/hysteresis_trigger.ex
+++ b/lib/grovepi/sound/hysteresis_trigger.ex
@@ -1,72 +1,107 @@
 defmodule GrovePi.Sound.HysteresisTrigger do
+  @behaviour GrovePi.Trigger
+
+  @default_high_threshold 510
+  @default_low_threshold 490
+
+
   @moduledoc """
   This is the default triggering mechanism for Sound events. Events
-  are either `pressed` or `released` and include the trigger state.
-  The trigger state for the default trigger is a struct containing
-  a `value` property. The lower reset threshold is 490 and the high
-  reset threshold is 510.
+  are either `loud` or `quiet` and include the trigger state. It
+  contains to thresholds a `low_threshold` and a `high_threshold` for
+  triggering `loud` and `quiet` events.
+
+  This trigger will not fire an event unless it has fired the opposite
+  event or if it is the first event fired. If a `loud` event fires it
+  will not be able to fire again unless a `quiet` event is fired. This
+  is to keep from having a trigger float near the trigger value and
+  become excessively noisy.
+
+
 
   ## Examples
-      iex> GrovePi.Sound.HysteresisTrigger.initial_state
-      %GrovePi.Sound.HysteresisTrigger.State{value: 500, last_event: :none}
+      iex> GrovePi.Sound.HysteresisTrigger.init([])
+      {:ok, %GrovePi.Sound.HysteresisTrigger.State{value: 500, fireable: :any, low_threshold: 490, high_threshold: 510}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.init(low_threshold: 10, high_threshold: 200)
+      {:ok, %GrovePi.Sound.HysteresisTrigger.State{value: 500, fireable: :any, low_threshold: 10, high_threshold: 200}}
 
   ### When there has been no event
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(499, %{value: 500, last_event: :none})
-      {:ok, %{value: 499, last_event: :none}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(499, %{value: 500, fireable: :any, low_threshold: 490, high_threshold: 500})
+      {:ok, %{value: 499, fireable: :any, low_threshold: 490, high_threshold: 500}}
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(489, %{value: 500, last_event: :none})
-      {:quiet, %{value: 489, last_event: :quiet}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(489, %{value: 500, fireable: :any, low_threshold: 490, high_threshold: 500})
+      {:quiet, %{value: 489, fireable: :loud, low_threshold: 490, high_threshold: 500}}
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(511, %{value: 500, last_event: :none})
-      {:loud, %{value: 511, last_event: :loud}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(511, %{value: 500, fireable: :any, low_threshold: 490, high_threshold: 500})
+      {:loud, %{value: 511, fireable: :quiet, low_threshold: 490, high_threshold: 500}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(21, %{value: 500, fireable: :any, low_threshold: 10, high_threshold: 20})
+      {:loud, %{value: 21, fireable: :quiet, low_threshold: 10, high_threshold: 20}}
 
   ### When the last event was loud
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(511, %{value: 500, last_event: :loud})
-      {:ok, %{value: 511, last_event: :loud}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(511, %{value: 500, fireable: :quiet, low_threshold: 490, high_threshold: 500})
+      {:ok, %{value: 511, fireable: :quiet, low_threshold: 490, high_threshold: 500}}
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(501, %{value: 500, last_event: :loud})
-      {:ok, %{value: 501, last_event: :loud}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(501, %{value: 500, fireable: :quiet, low_threshold: 490, high_threshold: 500})
+      {:ok, %{value: 501, fireable: :quiet, low_threshold: 490, high_threshold: 500}}
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(489, %{value: 500, last_event: :loud})
-      {:quiet, %{value: 489, last_event: :quiet}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(489, %{value: 500, fireable: :quiet, low_threshold: 490, high_threshold: 500})
+      {:quiet, %{value: 489, fireable: :loud, low_threshold: 490, high_threshold: 500}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(9, %{value: 500, fireable: :quiet, low_threshold: 10, high_threshold: 20})
+      {:quiet, %{value: 9, fireable: :loud, low_threshold: 10, high_threshold: 20}}
 
   ### When the last event was quiet
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(470, %{value: 500, last_event: :quiet})
-      {:ok, %{value: 470, last_event: :quiet}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(470, %{value: 500, fireable: :loud, low_threshold: 490, high_threshold: 500})
+      {:ok, %{value: 470, fireable: :loud, low_threshold: 490, high_threshold: 500}}
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(491, %{value: 500, last_event: :quiet})
-      {:ok, %{value: 491, last_event: :quiet}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(491, %{value: 500, fireable: :loud, low_threshold: 490, high_threshold: 500})
+      {:ok, %{value: 491, fireable: :loud, low_threshold: 490, high_threshold: 500}}
 
-      iex> GrovePi.Sound.HysteresisTrigger.update(521, %{value: 500, last_event: :quiet})
-      {:loud, %{value: 521, last_event: :loud}}
+      iex> GrovePi.Sound.HysteresisTrigger.update(521, %{value: 500, fireable: :loud, low_threshold: 490, high_threshold: 500})
+      {:loud, %{value: 521, fireable: :quiet, low_threshold: 490, high_threshold: 500}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(21, %{value: 500, fireable: :loud, low_threshold: 10, high_threshold: 20})
+      {:loud, %{value: 21, fireable: :quiet, low_threshold: 10, high_threshold: 20}}
   """
 
   defmodule State do
     @moduledoc false
-    defstruct value: 500, last_event: :none
+    @enforce_keys [:high_threshold, :low_threshold]
+    defstruct value: 500, fireable: :any, high_threshold: nil, low_threshold: nil
   end
 
-  def initial_state do
-    %State{}
+  @doc """
+  # Options
+
+  * `:high_threshold` - The level that must be exceeded to fire a loud event, The default is `510`
+  * `:low_threshold` - The level that must be recede below to fire a quiet event, The default is `490`
+  """
+  def init(opts) do
+    high_threshold = Keyword.get(opts, :high_threshold, @default_high_threshold)
+    low_threshold = Keyword.get(opts, :low_threshold, @default_low_threshold)
+
+    {:ok, %State{high_threshold: high_threshold, low_threshold: low_threshold}}
   end
 
-  def update(new_value, %{last_event: :none} = state) when new_value < 490 do
-    {:quiet, %{state | value: new_value, last_event: :quiet}}
+  def update(new_value, %{fireable: :any, low_threshold: low_threshold} = state) when new_value < low_threshold do
+    {:quiet, %{state | value: new_value, fireable: :loud}}
   end
 
-  def update(new_value, %{last_event: :none} = state) when new_value > 510 do
-    {:loud, %{state | value: new_value, last_event: :loud}}
+  def update(new_value, %{fireable: :any, high_threshold: high_threshold} = state) when new_value > high_threshold do
+    {:loud, %{state | value: new_value, fireable: :quiet}}
   end
 
-  def update(new_value, %{last_event: :loud} = state) when new_value < 490 do
-    {:quiet, %{state | value: new_value, last_event: :quiet}}
+  def update(new_value, %{fireable: :quiet, low_threshold: low_threshold} = state) when new_value < low_threshold do
+    {:quiet, %{state | value: new_value, fireable: :loud}}
   end
 
-  def update(new_value, %{last_event: :quiet} = state) when new_value > 510 do
-    {:loud, %{state | value: new_value, last_event: :loud}}
+  def update(new_value, %{fireable: :loud, high_threshold: high_threshold} = state) when new_value > high_threshold do
+    {:loud, %{state | value: new_value, fireable: :quiet}}
   end
 
   def update(new_value, state) do

--- a/lib/grovepi/sound/hysteresis_trigger.ex
+++ b/lib/grovepi/sound/hysteresis_trigger.ex
@@ -1,0 +1,75 @@
+defmodule GrovePi.Sound.HysteresisTrigger do
+  @moduledoc """
+  This is the default triggering mechanism for Sound events. Events
+  are either `pressed` or `released` and include the trigger state.
+  The trigger state for the default trigger is a struct containing
+  a `value` property. The lower reset threshold is 490 and the high
+  reset threshold is 510.
+
+  ## Examples
+      iex> GrovePi.Sound.HysteresisTrigger.initial_state
+      %GrovePi.Sound.HysteresisTrigger.State{value: 500, last_event: :none}
+
+  ### When there has been no event
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(499, %{value: 500, last_event: :none})
+      {:ok, %{value: 499, last_event: :none}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(489, %{value: 500, last_event: :none})
+      {:quiet, %{value: 489, last_event: :quiet}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(511, %{value: 500, last_event: :none})
+      {:loud, %{value: 511, last_event: :loud}}
+
+  ### When the last event was loud
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(511, %{value: 500, last_event: :loud})
+      {:ok, %{value: 511, last_event: :loud}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(501, %{value: 500, last_event: :loud})
+      {:ok, %{value: 501, last_event: :loud}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(489, %{value: 500, last_event: :loud})
+      {:quiet, %{value: 489, last_event: :quiet}}
+
+  ### When the last event was quiet
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(470, %{value: 500, last_event: :quiet})
+      {:ok, %{value: 470, last_event: :quiet}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(491, %{value: 500, last_event: :quiet})
+      {:ok, %{value: 491, last_event: :quiet}}
+
+      iex> GrovePi.Sound.HysteresisTrigger.update(521, %{value: 500, last_event: :quiet})
+      {:loud, %{value: 521, last_event: :loud}}
+  """
+
+  defmodule State do
+    @moduledoc false
+    defstruct value: 500, last_event: :none
+  end
+
+  def initial_state do
+    %State{}
+  end
+
+  def update(new_value, %{last_event: :none} = state) when new_value < 490 do
+    {:quiet, %{state | value: new_value, last_event: :quiet}}
+  end
+
+  def update(new_value, %{last_event: :none} = state) when new_value > 510 do
+    {:loud, %{state | value: new_value, last_event: :loud}}
+  end
+
+  def update(new_value, %{last_event: :loud} = state) when new_value < 490 do
+    {:quiet, %{state | value: new_value, last_event: :quiet}}
+  end
+
+  def update(new_value, %{last_event: :quiet} = state) when new_value > 510 do
+    {:loud, %{state | value: new_value, last_event: :loud}}
+  end
+
+  def update(new_value, state) do
+    {:ok, %{state | value: new_value}}
+  end
+end

--- a/lib/grovepi/sound/hysteresis_trigger.ex
+++ b/lib/grovepi/sound/hysteresis_trigger.ex
@@ -4,7 +4,6 @@ defmodule GrovePi.Sound.HysteresisTrigger do
   @default_high_threshold 510
   @default_low_threshold 490
 
-
   @moduledoc """
   This is the default triggering mechanism for Sound events. Events
   are either `loud` or `quiet` and include the trigger state. It

--- a/lib/grovepi/trigger.ex
+++ b/lib/grovepi/trigger.ex
@@ -1,0 +1,27 @@
+defmodule GrovePi.Trigger do
+  @moduledoc """
+  The Trigger behaviour is used for implementing triggers for poller
+  behaviors such as `GrovePi.Sound` and `GrovePi.Button`. The triggers
+  must implement two callbacks, init and update.
+  """
+
+  @type event :: atom
+  @type state :: struct
+
+  @doc """
+  The init callback that must return `{:ok, state}` or an error tuple.
+  """
+  @callback init(args :: term) :: {:ok, state} | {:error, reason :: any}
+
+  @callback update(any, state) :: {event, state}
+
+  def __using__(_) do
+    quote location: :keep do
+      @behaviour GrovePi.Trigger
+
+      def init(args) do
+        {:ok, args}
+      end
+    end
+  end
+end

--- a/test/grovepi/sound/hysteresis_trigger_test.exs
+++ b/test/grovepi/sound/hysteresis_trigger_test.exs
@@ -1,0 +1,4 @@
+defmodule GrovePi.Sound.HysteresisTriggerTest do
+  use ExUnit.Case, async: true
+  doctest GrovePi.Sound.HysteresisTrigger
+end

--- a/test/sound_test.exs
+++ b/test/sound_test.exs
@@ -1,0 +1,61 @@
+defmodule GrovePi.SoundTest do
+  use ComponentTestCase, async: true
+  @exceeded_threshold <<1, 511::size(16)>>
+  @under_threshold <<1, 489::size(16)>>
+
+  setup %{prefix: prefix} = tags do
+    poll_interval = Map.get(tags, :poll_interval, 1)
+
+    {:ok, _} = GrovePi.Sound.start_link(@pin,
+                                         poll_interval: poll_interval,
+                                         prefix: prefix,
+                                       )
+
+      {:ok, tags}
+  end
+
+  test "registering for a loud event receives loud messages",
+  %{prefix: prefix, board: board} do
+    GrovePi.Sound.subscribe(@pin, :loud, prefix)
+    GrovePi.I2C.add_responses(board, [@exceeded_threshold])
+
+    assert_receive {@pin, :loud, _}, 300
+  end
+
+  test "registering for a quiet event receives quiet messages",
+  %{prefix: prefix, board: board} do
+    GrovePi.Sound.subscribe(@pin, :quiet, prefix)
+    GrovePi.I2C.add_responses(board, [@under_threshold])
+
+    assert_receive {@pin, :quiet, _}, 300
+  end
+
+  @tag :capture_log
+  test "recovers from I2C error",
+  %{prefix: prefix, board: board} do
+    GrovePi.Sound.subscribe(@pin, :quiet, prefix)
+    GrovePi.I2C.add_responses(board, [
+                                {:error, :i2c_write_failed},
+                                @exceeded_threshold,
+                                @under_threshold,
+                              ])
+
+    assert_receive {@pin, :quiet, _}, 300
+  end
+
+  @tag poll_interval: 1_000_000
+  test "reading notifies subscribers",
+  %{prefix: prefix, board: board} do
+    GrovePi.Sound.subscribe(@pin, :quiet, prefix)
+    GrovePi.Sound.subscribe(@pin, :loud, prefix)
+    GrovePi.I2C.add_responses(board, [@exceeded_threshold, @under_threshold, @exceeded_threshold])
+
+    GrovePi.Sound.read(@pin, prefix)
+
+    assert_receive {@pin, :loud, _}, 10
+
+    GrovePi.Sound.read(@pin, prefix)
+
+    assert_receive {@pin, :quiet, _}, 10
+  end
+end


### PR DESCRIPTION
The default trigger for sound is a hysteresis trigger with thresholds
set at 490 and 510. This trigger will only fire when a threshold when
the opposite trigger is fired.

Extracted a poller module for polling type interfaces.

The polling modules require a few arguments. These are for setting the
default triggering mechanism and the read type. The read type is the
type of return value from the read_value callback. The read value
callback is required to be implemented. This callback is how we get the
data into the poller.

Amos King @adkron <amos@binarynoggin.com>