### PR TITLE
Add ability to change the polling interval while running

### DIFF
--- a/lib/grovepi/analog.ex
+++ b/lib/grovepi/analog.ex
@@ -62,5 +62,4 @@ defmodule GrovePi.Analog do
   def write(pin, value) do
     write(Default, pin, value)
   end
-
 end

--- a/lib/grovepi/poller.ex
+++ b/lib/grovepi/poller.ex
@@ -90,7 +90,7 @@ defmodule GrovePi.Poller do
 
       def handle_cast({:change_polling, interval}, %State{poll_reference: poll_reference} = state) do
         Process.cancel_timer(poll_reference)
-        {:noreply, schedule_poll(%{state | poll_interval: interval, poll_reference: nil}) }
+        {:noreply, schedule_poll(%{state | poll_interval: interval, poll_reference: nil})}
       end
 
       def handle_call(:read, _from, state) do

--- a/lib/grovepi/poller.ex
+++ b/lib/grovepi/poller.ex
@@ -55,12 +55,6 @@ defmodule GrovePi.Poller do
         {:ok, state_with_poll_reference}
       end
 
-      def schedule_poll(%{poll_interval: 0} = state), do: state
-
-      def schedule_poll(%State{poll_interval: poll_interval} = state) do
-        %{state | poll_reference: Process.send_after(self(), :poll_button, poll_interval)}
-      end
-
       @doc """
         Stops polling immediately
       """
@@ -119,6 +113,13 @@ defmodule GrovePi.Poller do
       defp notify({event, trigger_state}, prefix, pin) do
         Subscriber.notify_change(prefix, {pin, event, trigger_state})
       end
+
+      defp schedule_poll(%{poll_interval: 0} = state), do: state
+
+      defp schedule_poll(%State{poll_interval: poll_interval} = state) do
+        %{state | poll_reference: Process.send_after(self(), :poll_button, poll_interval)}
+      end
+
     end
   end
 end

--- a/test/button_test.exs
+++ b/test/button_test.exs
@@ -14,22 +14,6 @@ defmodule GrovePi.ButtonTest do
       {:ok, tags}
   end
 
-  test "registering for a pressed event receives pressed messages",
-  %{prefix: prefix, board: board} do
-    GrovePi.Button.subscribe(@pin, :pressed, prefix)
-    GrovePi.I2C.add_responses(board, [@pressed])
-
-    assert_receive {@pin, :pressed, _}, 300
-  end
-
-  test "registering for a released event receives released messages",
-  %{prefix: prefix, board: board} do
-    GrovePi.Button.subscribe(@pin, :released, prefix)
-    GrovePi.I2C.add_responses(board, [@pressed, @released])
-
-    assert_receive {@pin, :released, _}, 300
-  end
-
   @tag :capture_log
   test "recovers from I2C error",
   %{prefix: prefix, board: board} do
@@ -44,18 +28,16 @@ defmodule GrovePi.ButtonTest do
   end
 
   @tag poll_interval: 1_000_000
-  test "reading notifies subscribers",
+  test "reading gets from the grovepi board",
   %{prefix: prefix, board: board} do
-    GrovePi.Button.subscribe(@pin, :released, prefix)
-    GrovePi.Button.subscribe(@pin, :pressed, prefix)
-    GrovePi.I2C.add_responses(board, [@pressed, @released, @pressed])
+    GrovePi.I2C.add_responses(board, [@pressed, @released])
 
-    GrovePi.Button.read(@pin, prefix)
+    assert GrovePi.Button.read(@pin, prefix) == 1
 
-    assert_receive {@pin, :pressed, _}, 10
+    assert <<1, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
 
-    GrovePi.Button.read(@pin, prefix)
+    assert GrovePi.Button.read(@pin, prefix) == 0
 
-    assert_receive {@pin, :released, _}, 10
+    assert <<1, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
   end
 end

--- a/test/poller_test.exs
+++ b/test/poller_test.exs
@@ -1,0 +1,88 @@
+defmodule GrovePi.PollerTest do
+  use ComponentTestCase, async: true
+
+  defmodule TestTrigger do
+    use GrovePi.Trigger
+
+    def init(_) do
+      {:ok, []}
+    end
+
+    def update(value, _), do: {:trigger, value}
+  end
+
+  defmodule TestPoller do
+    use GrovePi.Poller, default_trigger: GrovePi.PollerTest.TestTrigger, read_type: :integer
+
+    def read_value(_, _) do
+      1
+    end
+  end
+
+  setup %{prefix: prefix} = tags do
+    poll_interval = Map.get(tags, :poll_interval, 1)
+
+    {:ok, pid} = TestPoller.start_link(@pin,
+                                     poll_interval: poll_interval,
+                                     prefix: prefix,
+                                   )
+
+    tags = Map.put(tags, :poller, pid)
+    {:ok, tags}
+  end
+
+  test "registering for a an event receives event messages",
+  %{prefix: prefix} do
+    TestPoller.subscribe(@pin, :trigger, prefix)
+
+    assert_receive {@pin, :trigger, _}, 300
+  end
+
+  @tag poll_interval: 1_000_000
+  test "reading notifies subscribers",
+  %{prefix: prefix} do
+    TestPoller.subscribe(@pin, :trigger, prefix)
+
+    TestPoller.read(@pin, prefix)
+
+    assert_receive {@pin, :trigger, _}, 10
+  end
+
+  @tag poll_interval: 1_000_000
+  test "stop polling",
+  %{prefix: prefix, poller: poller} do
+    %{poll_reference: reference, poll_interval: 1_000_000} = :sys.get_state(poller)
+
+    assert Process.read_timer(reference)
+
+    assert TestPoller.stop_polling(@pin, prefix) == :ok
+
+    %{poll_reference: nil, poll_interval: 0} = :sys.get_state(poller)
+
+    refute Process.read_timer(reference)
+  end
+
+  @tag poll_interval: 1_000_000
+  test "changing polling",
+  %{prefix: prefix, poller: poller} do
+    %{poll_reference: reference, poll_interval: 1_000_000} = :sys.get_state(poller)
+
+    assert Process.read_timer(reference)
+
+    new_interval = 10_000
+    assert TestPoller.change_polling(@pin, new_interval, prefix) == :ok
+
+    %{poll_reference: new_reference, poll_interval: ^new_interval} = :sys.get_state(poller)
+
+    assert Process.read_timer(new_reference)
+    refute Process.read_timer(reference)
+  end
+
+  @tag poll_interval: 0
+  test "no polling does not schedule a polling message",
+  %{poller: poller} do
+    %{poll_reference: reference, poll_interval: 0} = :sys.get_state(poller)
+
+    refute reference
+  end
+end

--- a/test/sound_test.exs
+++ b/test/sound_test.exs
@@ -14,22 +14,6 @@ defmodule GrovePi.SoundTest do
       {:ok, tags}
   end
 
-  test "registering for a loud event receives loud messages",
-  %{prefix: prefix, board: board} do
-    GrovePi.Sound.subscribe(@pin, :loud, prefix)
-    GrovePi.I2C.add_responses(board, [@exceeded_threshold])
-
-    assert_receive {@pin, :loud, _}, 300
-  end
-
-  test "registering for a quiet event receives quiet messages",
-  %{prefix: prefix, board: board} do
-    GrovePi.Sound.subscribe(@pin, :quiet, prefix)
-    GrovePi.I2C.add_responses(board, [@under_threshold])
-
-    assert_receive {@pin, :quiet, _}, 300
-  end
-
   @tag :capture_log
   test "recovers from I2C error",
   %{prefix: prefix, board: board} do
@@ -46,16 +30,14 @@ defmodule GrovePi.SoundTest do
   @tag poll_interval: 1_000_000
   test "reading notifies subscribers",
   %{prefix: prefix, board: board} do
-    GrovePi.Sound.subscribe(@pin, :quiet, prefix)
-    GrovePi.Sound.subscribe(@pin, :loud, prefix)
-    GrovePi.I2C.add_responses(board, [@exceeded_threshold, @under_threshold, @exceeded_threshold])
+    GrovePi.I2C.add_responses(board, [@exceeded_threshold, @under_threshold])
 
-    GrovePi.Sound.read(@pin, prefix)
+    assert GrovePi.Sound.read(@pin, prefix) == 511
 
-    assert_receive {@pin, :loud, _}, 10
+    assert <<3, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
 
-    GrovePi.Sound.read(@pin, prefix)
+    assert GrovePi.Sound.read(@pin, prefix) == 489
 
-    assert_receive {@pin, :quiet, _}, 10
+    assert <<3, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
   end
 end


### PR DESCRIPTION
The polling interval can be stopped with `stop_polling/2` or changed to
a new interval with `change_polling/3`. The original scheduled polling
event is stopped in the process and the new timer starts immediately.

Closes #14 

Amos King @adkron <amos@binarynoggin.com>