### PR TITLE
Fix typo in GrovePi.Button documentation

### DIFF
--- a/lib/grovepi/button.ex
+++ b/lib/grovepi/button.ex
@@ -7,8 +7,8 @@ defmodule GrovePi.Button do
   @moduledoc """
   Listen for events from a GrovePi button. There are two types of
   events by defualt; pressed and released. When registering for an event the button
-  will then send a message of `{pin, :pressed, {value: 1}` or
-  `{pin, :released, {value: 0}}`. The button works by polling
+  will then send a message of `{pin, :pressed, %{value: 1}` or
+  `{pin, :released, %{value: 0}}`. The button works by polling
   `GrovePi.Digital` on the pin that you have registered to a button.
 
   Example usage:


### PR DESCRIPTION
I found a typo in the GrovePi.Button documentation.