### PR TITLE
Potentiometer

### DIFF
--- a/examples/alarm/README.md
+++ b/examples/alarm/README.md
@@ -5,7 +5,7 @@ This example sounds an alarm after a button is pressed.
 On the GrovePi+ or GrovePi Zero, connect a button to port A0
 and a buzzer to port D3.
 
-If you're on Raspbian, trying this out by running:
+If you're on Raspbian, try this out by running:
 ```
 mix deps.get
 MIX_ENV=prod mix compile

--- a/examples/led_fade/.gitignore
+++ b/examples/led_fade/.gitignore
@@ -1,0 +1,20 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/examples/led_fade/README.md
+++ b/examples/led_fade/README.md
@@ -1,0 +1,13 @@
+# LED Fade
+
+This project fades an LED when you turn a potentiometer knob.
+
+On the GrovePi+ or GrovePi Zero, connect a potentiometer to port A2 and a LED to port D3.
+
+If you're on Raspbian, try this out by running:
+
+```shell
+mix deps.get
+MIX_ENV=prod mix compile
+MIX_ENV=prod iex -S mix
+```

--- a/examples/led_fade/config/config.exs
+++ b/examples/led_fade/config/config.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/examples/led_fade/lib/led_fade.ex
+++ b/examples/led_fade/lib/led_fade.ex
@@ -1,0 +1,35 @@
+defmodule LEDFade do
+  @moduledoc false
+  use GenServer
+
+  defstruct [:potentiometer, :led]
+
+  def start_link(pins) do
+    GenServer.start_link(__MODULE__, pins)
+  end
+
+  def init([potentiometer, led]) do
+    state = %LEDFade{potentiometer: potentiometer, led: led}
+
+    GrovePi.Potentiometer.subscribe(potentiometer, :changed)
+    {:ok, state}
+  end
+
+  def handle_info({_, :changed, %{value: value}}, state) do
+    led_value = convert_to_pwm(value)
+
+    # Write new value to led
+    GrovePi.Analog.write(state.led, led_value)
+
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
+  defp convert_to_pwm(value) do
+    # Convert adc_level value (0-1023) to pwm value (0-255)
+    round(value / 5)
+  end
+end

--- a/examples/led_fade/lib/led_fade/application.ex
+++ b/examples/led_fade/lib/led_fade/application.ex
@@ -1,0 +1,22 @@
+defmodule LEDFade.Application do
+  @moduledoc false
+  use Application
+
+  @potentiometer_pin 16 # Port A2
+  @led_pin 3 # Port D3
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    children = [
+      # Start the GrovePi sensor that we want
+      worker(GrovePi.Potentiometer, [@potentiometer_pin]),
+
+      # Start the main app
+      worker(LEDFade, [[@potentiometer_pin, @led_pin]]),
+    ]
+
+    opts = [strategy: :one_for_one, name: LEDFade.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/examples/led_fade/mix.exs
+++ b/examples/led_fade/mix.exs
@@ -1,0 +1,21 @@
+defmodule LEDFade.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :led_fade,
+     version: "0.1.0",
+     elixir: "~> 1.4",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps()]
+  end
+
+  def application do
+    [extra_applications: [:logger],
+     mod: {LEDFade.Application, []}]
+  end
+
+  defp deps do
+    [{:grovepi, path: "../.."}]
+  end
+end

--- a/examples/led_fade/mix.lock
+++ b/examples/led_fade/mix.lock
@@ -1,0 +1,2 @@
+%{"elixir_ale": {:hex, :elixir_ale, "0.7.0", "8c0c4b40e5e0ba869c8100c10f9e6fd09191204dd3c6c99add232fdb4e2a341a", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, optional: false]}]},
+  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []}}

--- a/lib/grovepi/button.ex
+++ b/lib/grovepi/button.ex
@@ -6,14 +6,14 @@ defmodule GrovePi.Button do
 
   @moduledoc """
   Listen for events from a GrovePi button. There are two types of
-  events by defualt; pressed and released. When registering for an event the button
-  will then send a message of `{pin, :pressed, %{value: 1}` or
+  events by default; pressed and released. When registering for an event the
+  button will then send a message of `{pin, :pressed, %{value: 1}` or
   `{pin, :released, %{value: 0}}`. The button works by polling
   `GrovePi.Digital` on the pin that you have registered to a button.
 
   Example usage:
   ```
-  iex> {:ok, button}=GrovePi.Button.start_link(3)
+  iex> {:ok, button} = GrovePi.Button.start_link(3)
   :ok
   iex> GrovePi.Button.subscribe(3, :pressed)
   :ok

--- a/lib/grovepi/buzzer.ex
+++ b/lib/grovepi/buzzer.ex
@@ -5,7 +5,7 @@ defmodule GrovePi.Buzzer do
 
   Example usage:
   ```
-  iex> {:ok, buzzer}=GrovePi.Buzzer.start_link(3)
+  iex> {:ok, buzzer} = GrovePi.Buzzer.start_link(3)
   :ok
   iex> GrovePi.Buzzer.buzz(3)
   :ok

--- a/lib/grovepi/dht.ex
+++ b/lib/grovepi/dht.ex
@@ -8,7 +8,7 @@ defmodule GrovePi.DHT do
 
   ```
   iex> pin = 3
-  iex> {:ok, pid}=GrovePi.DHT.start_link(pin)
+  iex> {:ok, pid} = GrovePi.DHT.start_link(pin)
   {:ok, #PID<0.199.0>}
   iex> GrovePi.DHT.read_temp_and_humidity(pin)
   {23.0, 40.0}

--- a/lib/grovepi/potentiometer.ex
+++ b/lib/grovepi/potentiometer.ex
@@ -1,0 +1,40 @@
+defmodule GrovePi.Potentiometer do
+  alias GrovePi.Analog
+
+  use GrovePi.Poller, default_trigger: GrovePi.Potentiometer.DefaultTrigger,
+  read_type: Analog.adc_level
+
+  @moduledoc """
+  Listen for events from a GrovePi potentiometer or rotary angle sensor. There
+  is only one type of event by default; `:changed`. When registering for an
+  event the potentiometer will send a message similar to
+  `{pin, :changed, {value: 1}` with the value being a number from 0-1023
+  that maps to 0 to 5 volts.  The potentiometer works by polling
+  `GrovePi.Analog` on the pin that you have registered to a potentiometer.
+
+  Example usage:
+  ```
+  iex> {:ok, potentiometer} = GrovePi.Potentiometer.start_link(16)
+  :ok
+  iex> GrovePi.Potentiometer.subscribe(16, :changed)
+  :ok
+  ```
+
+  The `GrovePi.Potentiometer.DefaultTrigger` is written so when the value of
+  the potentiometer changes, the subscribed process will receive a message in
+  the form of `{pid, :changed, %{value: value}`. The message should be
+  received using GenServer handle_info/2.
+
+  For example:
+  ```
+  def handle_info({_pid, :changed, %{value: value}}, state) do
+    # do something with `value`
+    {:noreply, state}
+  end
+  ```
+  """
+
+  def read_value(prefix, pin) do
+    Analog.read(prefix, pin)
+  end
+end

--- a/lib/grovepi/potentiometer/default_trigger.ex
+++ b/lib/grovepi/potentiometer/default_trigger.ex
@@ -1,0 +1,40 @@
+defmodule GrovePi.Potentiometer.DefaultTrigger do
+  @behaviour GrovePi.Trigger
+
+  @moduledoc """
+  This is the default triggering mechanism for Potentiometer events. The
+  event is `:changed` and includes the trigger state. The trigger state
+  for the default trigger is a struct containing a `value` property.
+
+  ## Examples
+      iex> GrovePi.Potentiometer.DefaultTrigger.init([])
+      {:ok, %GrovePi.Potentiometer.DefaultTrigger.State{value: 0}}
+
+      iex> GrovePi.Potentiometer.DefaultTrigger.update(0, %{value: 0})
+      {:ok, %{value: 0}}
+
+      iex> GrovePi.Potentiometer.DefaultTrigger.update(500, %{value: 0})
+      {:changed, %{value: 500}}
+
+      iex> GrovePi.Potentiometer.DefaultTrigger.update(500, %{value: 500})
+      {:ok, %{value: 500}}
+
+      iex> GrovePi.Potentiometer.DefaultTrigger.update(125, %{value: 500})
+      {:changed, %{value: 125}}
+  """
+
+  defmodule State do
+    @moduledoc false
+    defstruct value: 0
+  end
+
+  def init(_) do
+    {:ok, %State{}}
+  end
+
+  def update(value, %{value: value} = state), do: {:ok, state}
+
+  def update(new_value, state) do
+    {:changed, %{state | value: new_value}}
+  end
+end

--- a/lib/grovepi/sound.ex
+++ b/lib/grovepi/sound.ex
@@ -13,7 +13,7 @@ defmodule GrovePi.Sound do
 
   Example usage:
   ```
-  iex> {:ok, sound}=GrovePi.Sound.start_link(3)
+  iex> {:ok, sound} = GrovePi.Sound.start_link(3)
   :ok
   iex> GrovePi.Sound.subscribe(3, :loud)
   :ok

--- a/lib/grovepi/ultrasonic.ex
+++ b/lib/grovepi/ultrasonic.ex
@@ -5,7 +5,7 @@ defmodule GrovePi.Ultrasonic do
   Example use:
   ```
   iex> pin = 3
-  iex> {:ok, pid}=GrovePi.Ultrasonic.start_link(pin)
+  iex> {:ok, pid} = GrovePi.Ultrasonic.start_link(pin)
   {:ok, #PID<0.205.0>}
   iex> GrovePi.Ultrasonic.read_distance(pin)
   20

--- a/test/grovepi/potentiometer/default_trigger_test.exs
+++ b/test/grovepi/potentiometer/default_trigger_test.exs
@@ -1,0 +1,4 @@
+defmodule GrovePi.Potentiometer.DefaultTriggerTest do
+  use ExUnit.Case, async: true
+  doctest GrovePi.Potentiometer.DefaultTrigger
+end

--- a/test/potentiometer_test.exs
+++ b/test/potentiometer_test.exs
@@ -1,0 +1,43 @@
+defmodule GrovePi.PotentiometerTest do
+  use ComponentTestCase, async: true
+  @read_1 <<1>>
+  @read_2 <<120>>
+
+  setup %{prefix: prefix} = tags do
+    poll_interval = Map.get(tags, :poll_interval, 1)
+
+    {:ok, _} = GrovePi.Potentiometer.start_link(@pin,
+                                         poll_interval: poll_interval,
+                                         prefix: prefix,
+                                       )
+
+      {:ok, tags}
+  end
+
+  @tag :capture_log
+  test "recovers from I2C error",
+  %{prefix: prefix, board: board} do
+    GrovePi.Potentiometer.subscribe(@pin, :changed, prefix)
+    GrovePi.I2C.add_responses(board, [
+                                {:error, :i2c_write_failed},
+                                @read_1,
+                                @read_2,
+                              ])
+
+    assert_receive {@pin, :changed, _}, 300
+  end
+
+  @tag poll_interval: 1_000_000
+  test "reading gets from the grovepi board",
+  %{prefix: prefix, board: board} do
+    GrovePi.I2C.add_responses(board, [@read_1, @read_2])
+
+    assert GrovePi.Potentiometer.read(@pin, prefix) == <<1>>
+
+    assert <<3, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
+
+    assert GrovePi.Potentiometer.read(@pin, prefix) == <<120>>
+
+    assert <<3, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
+  end
+end


### PR DESCRIPTION
Here is the Potentiometer poller and the LED Fade project PR.  The Potentiometer may be applicable to any Analog device, so a more generic name might be more appropriate.  Let me know what changes you would like me to make.