### PR TITLE
Add poller for DHT11 sensor

### DIFF
--- a/examples/home_weather_display/.gitignore
+++ b/examples/home_weather_display/.gitignore
@@ -1,0 +1,12 @@
+# App artifacts
+/_build
+/db
+/deps
+/*.ez
+
+# Nerves artifacts
+/_images
+/.nerves
+
+# Generate on crash by the VM
+erl_crash.dump

--- a/examples/home_weather_display/README.md
+++ b/examples/home_weather_display/README.md
@@ -1,0 +1,14 @@
+# Home Weather Display
+
+This example reads a digital humidity and temperature (DHT) sensor and updates a 
+RGB LCD display.  The project is configured for the DHT11 sensor which comes with 
+the GrovePi+ Starter Kit (the blue one).
+
+On the GrovePi+ or GrovePi Zero, connect a DHT11 to port 7 and a RGB LCD display 
+to the IC2-1 port.
+
+This project was created as a Nerves app. To start your Nerves app:
+  * `export NERVES_TARGET=my_target` or prefix every command with `NERVES_TARGET=my_target`, Example: `NERVES_TARGET=rpi3`
+  * Install dependencies with `mix deps.get`
+  * Create firmware with `mix firmware`
+  * Burn to an SD card with `mix firmware.burn`

--- a/examples/home_weather_display/config/config.exs
+++ b/examples/home_weather_display/config/config.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/examples/home_weather_display/lib/home_weather_display.ex
+++ b/examples/home_weather_display/lib/home_weather_display.ex
@@ -1,0 +1,40 @@
+defmodule HomeWeatherDisplay do
+  @moduledoc false
+  use GenServer
+
+  defstruct [:dht]
+
+  alias GrovePi.{RGBLCD, DHT11}
+
+  def start_link(pin) do
+    GenServer.start_link(__MODULE__, pin)
+  end
+
+  def init([dht_pin]) do
+    state = %HomeWeatherDisplay{dht: dht_pin}
+
+    DHT11.subscribe(dht_pin, :changed)
+    {:ok, state}
+  end
+
+  def handle_info({_pid, :changed, %{temp: temp, humidity: humidity}}, state) do
+    text = format_text(temp, humidity)
+
+    # Flash RGB LCD screen before change
+    RGBLCD.set_rgb(0, 128, 64)
+    RGBLCD.set_rgb(0, 255, 0)
+
+    # Update LCD with new data
+    RGBLCD.set_text(text)
+
+    {:ok, state}
+  end
+
+  def handle_info(_message, state) do
+    {:ok, state}
+  end
+
+  defp format_text(temp, humidity) do
+    "Temp: #{Float.to_string(temp)}C  Humidity: #{Float.to_string(humidity)}%"
+  end
+end

--- a/examples/home_weather_display/lib/home_weather_display/application.ex
+++ b/examples/home_weather_display/lib/home_weather_display/application.ex
@@ -1,0 +1,22 @@
+defmodule HomeWeatherDisplay.Application do
+  @moduledoc false
+  use Application
+
+  # RGB LCD Screen should use the IC2-1 port
+  @dht_pin 7 # Use port 7 for the DHT
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    children = [
+      # Start the GrovePi sensor we want
+      worker(GrovePi.DHT11, [@dht_pin]),
+
+      # Start the main app
+      worker(HomeWeatherDisplay, [@dht_pin]),
+    ]
+
+    opts = [strategy: :one_for_one, name: HomeWeatherDisplay.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/examples/home_weather_display/mix.exs
+++ b/examples/home_weather_display/mix.exs
@@ -1,0 +1,72 @@
+defmodule HomeWeatherDisplay.Mixfile do
+  use Mix.Project
+
+  @target System.get_env("MIX_TARGET") || "host"
+  Mix.shell.info([:green, """
+  Env
+    MIX_TARGET:   #{@target}
+    MIX_ENV:      #{Mix.env}
+  """, :reset])
+  def project do
+    [app: :home_weather_display,
+     version: "0.1.0",
+     elixir: "~> 1.4.0",
+     target: @target,
+     archives: [nerves_bootstrap: "~> 0.3.0"],
+     deps_path: "deps/#{@target}",
+     build_path: "_build/#{@target}",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     aliases: aliases(@target),
+     deps: deps()]
+  end
+
+  # Configuration for the OTP application.
+  #
+  # Type `mix help compile.app` for more information.
+  def application, do: application(@target)
+
+  # Specify target specific application configurations
+  # It is common that the application start function will start and supervise
+  # applications which could cause the host to fail. Because of this, we only
+  # invoke HomeWeatherDisplay.start/2 when running on a target.
+  def application("host") do
+    [extra_applications: [:logger]]
+  end
+  def application(_target) do
+    [mod: {HomeWeatherDisplay.Application, []},
+     extra_applications: [:logger]]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:my_dep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:my_dep, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  def deps do
+    [
+      {:grovepi, path: "../.."},
+      {:nerves, "~> 0.5.0", runtime: false}
+    ] ++
+    deps(@target)
+  end
+
+  # Specify target specific dependencies
+  def deps("host"), do: []
+  def deps(target) do
+    [{:nerves_runtime, "~> 0.1.0"},
+     {:"nerves_system_#{target}", "~> 0.11.0", runtime: false}]
+  end
+
+  # We do not invoke the Nerves Env when running on the Host
+  def aliases("host"), do: []
+  def aliases(_target) do
+    ["deps.precompile": ["nerves.precompile", "deps.precompile"],
+     "deps.loadpaths":  ["deps.loadpaths", "nerves.loadpaths"]]
+  end
+
+end

--- a/examples/home_weather_display/mix.lock
+++ b/examples/home_weather_display/mix.lock
@@ -1,0 +1,10 @@
+%{"distillery": {:hex, :distillery, "1.4.0", "d633cd322c8efa0428082b00b7f902daf8caa166d45f9022bbc19a896d2e1e56", [:mix], []},
+  "elixir_ale": {:hex, :elixir_ale, "0.7.0", "8c0c4b40e5e0ba869c8100c10f9e6fd09191204dd3c6c99add232fdb4e2a341a", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, optional: false]}]},
+  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []},
+  "gen_stage": {:hex, :gen_stage, "0.11.0", "943bdfa85c75fa624e0a36a9d135baad20a523be040178f5a215444b45c66ea4", [:mix], []},
+  "nerves": {:hex, :nerves, "0.5.1", "a55d73752e8f271c7aca5fbe47747f07d0e7760b5e858e7f8da17ab06287f49c", [:mix], [{:distillery, "~> 1.0", [hex: :distillery, optional: false]}]},
+  "nerves_runtime": {:hex, :nerves_runtime, "0.1.2", "eeceaf6e2091831e8e6f2204c4c3817c98e90f0d4aa646bf0054d4680a0ef0a4", [:make, :mix], [{:elixir_make, "~> 0.3", [hex: :elixir_make, optional: false]}, {:gen_stage, "~> 0.4", [hex: :gen_stage, optional: false]}, {:nerves_uart, "~> 0.1.0", [hex: :nerves_uart, optional: true]}]},
+  "nerves_system_br": {:hex, :nerves_system_br, "0.9.4", "5096a9dfec49d4663ccb94c4a4fe45885303fbf31108f7e9400369bdec94b5e7", [:mix], []},
+  "nerves_system_rpi3": {:hex, :nerves_system_rpi3, "0.11.0", "c5da062ebee5a7d80e984d5675b92e5722c6d84354f46a558ef2e9d6460fe626", [:mix], [{:nerves, "~> 0.4", [hex: :nerves, optional: false]}, {:nerves_system_br, "~> 0.9.2", [hex: :nerves_system_br, optional: false]}, {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 0.10.0", [hex: :nerves_toolchain_arm_unknown_linux_gnueabihf, optional: false]}]},
+  "nerves_toolchain_arm_unknown_linux_gnueabihf": {:hex, :nerves_toolchain_arm_unknown_linux_gnueabihf, "0.10.0", "18200c6cc3fcda1cbe263b7f7d50ff05db495b881ade9436cd1667b3e8e62429", [:mix], [{:nerves, "~> 0.4", [hex: :nerves, optional: false]}, {:nerves_toolchain_ctng, "~> 0.9", [hex: :nerves_toolchain_ctng, optional: false]}]},
+  "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "0.9.0", "825b2b5bbacc3ad20c8513baafd44978616d5b451e6e052cdb727be81e7cdcac", [:mix], []}}

--- a/examples/home_weather_display/rel/vm.args
+++ b/examples/home_weather_display/rel/vm.args
@@ -1,0 +1,9 @@
+## Add custom options here
+
+## Start the Elixir shell
+-noshell
+-user Elixir.IEx.CLI
+-extra --no-halt
+
+## Options added here are interpreted as plain arguments and
+## can be retrieved using :init.get_plain_arguments().

--- a/lib/grovepi/dht_11.ex
+++ b/lib/grovepi/dht_11.ex
@@ -1,0 +1,45 @@
+defmodule GrovePi.DHT11 do
+  alias GrovePi.{DHT, Board}
+
+  use GrovePi.Poller, default_trigger: GrovePi.DHT11.DefaultTrigger,
+  read_type: Digital.level
+
+  @moduledoc """
+  Listen for events from a GrovePi DHT (Digital Humidity and Temparature)
+  sensor. This module is configured for the DHT11, the blue one, that comes
+  with the GrovePi+ Starter Kit. There is only one type of event by default;
+  `:changed`. When registering for an event the DHT11 will send a message in the
+  form of `{pin, :changed, %{temp: 11.3, humidity: 45.5}` with the temp and
+  humidty being floats. The `GrovePi.DHT11` module works by polling
+  the pin that you have registered to a DHT sensor.
+
+  Example usage:
+  ```
+  iex> {:ok, dht} = GrovePi.DHT11.start_link(7)
+  :ok
+  iex> GrovePi.DHT11.subscribe(7, :changed)
+  :ok
+  ```
+
+  The `GrovePi.DHT11.DefaultTrigger` is written so when the value of
+  the either the temp or humidity changes, the subscribed process will receive
+  a message in the form of `{pid, :changed, %{temp: 11.3, humidity: 45.5}`. The
+  message should be received using GenServer handle_info/2.
+
+  For example:
+  ```
+  def handle_info({_pid, :changed, %{temp: temp, humidity: humidity}}, state) do
+    # do something with temp and/or humidity
+    {:noreply, state}
+  end
+  ```
+  """
+  @module_type 0
+
+  def read_value(prefix, pin) do
+    with :ok <- Board.send_request(prefix, <<40, pin, @module_type, 0>>),
+          <<_, temp::little-float-size(32), humidity::little-float-size(32)>>
+            <- Board.get_response(prefix, 9),
+    do: {temp, humidity}
+  end
+end

--- a/lib/grovepi/dht_11/default_trigger.ex
+++ b/lib/grovepi/dht_11/default_trigger.ex
@@ -1,0 +1,39 @@
+defmodule GrovePi.DHT11.DefaultTrigger do
+  @behaviour GrovePi.Trigger
+
+  @moduledoc """
+  This is the default triggering mechanism for DHT11 events. The
+  event is `:changed` and includes the trigger state. The trigger state
+  for the default trigger is a struct containing `temp` and `humidity`
+  properties.
+
+  ## Examples
+      iex> GrovePi.DHT11.DefaultTrigger.init([])
+      {:ok, %GrovePi.DHT11.DefaultTrigger.State{temp: 0, humidity: 0}}
+      iex> GrovePi.DHT11.DefaultTrigger.update({0, 0}, %{temp: 0, humidity: 0})
+      {:ok, %{temp: 0, humidity: 0}}
+      iex> GrovePi.DHT11.DefaultTrigger.update({11.3, 45.5}, %{temp: 0, humidity: 0})
+      {:changed, %{temp: 11.3, humidity: 45.5}}
+      iex> GrovePi.DHT11.DefaultTrigger.update({11.3, 45.5}, %{temp: 11.3, humidity: 45.5})
+      {:ok, %{temp: 11.3, humidity: 45.5}}
+      iex> GrovePi.DHT11.DefaultTrigger.update({22.5, 34.5}, %{temp: 11.3, humidity: 45.5})
+      {:changed, %{temp: 22.5, humidity: 34.5}}
+  """
+
+  defmodule State do
+    @moduledoc false
+    defstruct temp: 0, humidity: 0
+  end
+
+  def init(_) do
+    {:ok, %State{}}
+  end
+
+  def update({temp, humidity}, %{temp: temp, humidity: humidity} = state) do
+    {:ok, state}
+  end
+
+  def update({new_temp, new_humidity}, state) do
+    {:changed, %{state | temp: new_temp, humidity: new_humidity}}
+  end
+end

--- a/test/dht_11_test.exs
+++ b/test/dht_11_test.exs
@@ -1,0 +1,43 @@
+defmodule GrovePi.DHT11Test do
+  use ComponentTestCase, async: true
+  @read_1 <<0, 23.0::little-float-size(32), 44.5::little-float-size(32)>>
+  @read_2 <<0, 13.5::little-float-size(32), 77.5::little-float-size(32)>>
+
+  setup %{prefix: prefix} = tags do
+    poll_interval = Map.get(tags, :poll_interval, 1)
+
+    {:ok, _} = GrovePi.DHT11.start_link(@pin,
+                                         poll_interval: poll_interval,
+                                         prefix: prefix,
+                                       )
+
+      {:ok, tags}
+  end
+
+  @tag :capture_log
+  test "recovers from I2C error",
+  %{prefix: prefix, board: board} do
+    GrovePi.DHT11.subscribe(@pin, :changed, prefix)
+    GrovePi.I2C.add_responses(board, [
+                                {:error, :i2c_write_failed},
+                                @read_1,
+                                @read_2,
+                              ])
+
+    assert_receive {@pin, :changed, _}, 300
+  end
+
+  @tag poll_interval: 1_000_000
+  test "reading gets from the grovepi board",
+  %{prefix: prefix, board: board} do
+    GrovePi.I2C.add_responses(board, [@read_1, @read_2])
+
+    assert GrovePi.DHT11.read(@pin, prefix) == {23.0, 44.5}
+
+    assert <<40, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
+
+    assert GrovePi.DHT11.read(@pin, prefix) == {13.5, 77.5}
+
+    assert <<40, @pin, 0, 0>> == GrovePi.I2C.get_last_write(board)
+  end
+end

--- a/test/grovepi/dht_11/default_trigger_test.exs
+++ b/test/grovepi/dht_11/default_trigger_test.exs
@@ -1,0 +1,4 @@
+defmodule GrovePi.DHT11.DefaultTriggerTest do
+  use ExUnit.Case, async: true
+  doctest GrovePi.DHT11.DefaultTrigger
+end


### PR DESCRIPTION
Add poller support for a DHT11 sensor.  An event is created for any
change to the humidity or temperature values.  The DHT11 is read using
the DHT module.  The module will only work with DHT module_type 0 which
is the sensor that comes with the GrovePi+ Starter Kit.

**This is a work in progress.**  

I'm trying to build the Home Weather Station project which uses a DHT and the RGBLCD.
https://github.com/DexterInd/GrovePi/blob/master/Projects/Home_Weather_Display/Home_Weather_Display.py