### PR TITLE
Home Weather example bug fixes and updates

### DIFF
--- a/examples/home_weather_display/lib/home_weather_display/application.ex
+++ b/examples/home_weather_display/lib/home_weather_display/application.ex
@@ -4,19 +4,20 @@ defmodule HomeWeatherDisplay.Application do
 
   # RGB LCD Screen should use the IC2-1 port
   @dht_pin 7 # Use port 7 for the DHT
+  @dht_poll_interval 1_000 # poll every 1 second
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     children = [
       # Start the GrovePi sensor we want
-      worker(GrovePi.DHT11, [@dht_pin]),
+      worker(GrovePi.DHT11, [@dht_pin, [poll_interval: @dht_poll_interval]]),
 
       # Start the main app
       worker(HomeWeatherDisplay, [@dht_pin]),
     ]
 
-    opts = [strategy: :one_for_one, name: HomeWeatherDisplay.Supervisor]
+    opts = [strategy: :rest_for_one, name: HomeWeatherDisplay.Supervisor]
     Supervisor.start_link(children, opts)
   end
 end

--- a/examples/home_weather_display/rel/config.exs
+++ b/examples/home_weather_display/rel/config.exs
@@ -1,0 +1,37 @@
+use Mix.Releases.Config,
+    # This sets the default release built by `mix release`
+    default_release: :default,
+    # This sets the default environment used by `mix release`
+    default_environment: :dev
+
+# For a full list of config options for both releases
+# and environments, visit https://hexdocs.pm/distillery/configuration.html
+
+# You may define one or more environments in this file,
+# an environment's settings will override those of a release
+# when building in that environment, this combination of release
+# and environment configuration is called a profile
+
+environment :dev do
+  set cookie: :"%!feck]DAK=vVwb*R}mZ@lkmNZ$]4._koGgzwwC7y7<^hrX*8s]a]X`{KO@{OSx4"
+end
+
+environment :prod do
+  set cookie: :"%!feck]DAK=vVwb*R}mZ@lkmNZ$]4._koGgzwwC7y7<^hrX*8s]a]X`{KO@{OSx4"
+end
+
+# You may define one or more releases in this file.
+# If you have not set a default release, or selected one
+# when running `mix release`, the first release in the file
+# will be used by default
+
+release :home_weather_display do
+  set version: current_version(:home_weather_display)
+  if System.get_env("NERVES_SYSTEM") do
+    set dev_mode: false
+    set include_src: false
+    set include_erts: System.get_env("ERL_LIB_DIR")
+    set include_system_libs: System.get_env("ERL_SYSTEM_LIB_DIR")
+    set vm_args: "rel/vm.args"
+  end
+end


### PR DESCRIPTION
This update fixes `HomeWeatherDisplay.init/1` argument and `HomeWeatherDisplay.handle_info/2` return format bugs. I increased the polling interval to 30s to minimize flicker. I shortened the text to get it to fit on the top line (I don't think the current `GrovePi.RGBLCD` implementation uses the second line). I made a couple other minor updates. It also adds the generated `rel/config.exs` file (not sure if this should be part of the project or included in .gitignore).